### PR TITLE
1: Print command help output to the channel as a codeblock

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,8 +150,7 @@ func main() {
 				eventApp := cli.NewApp()
 				eventApp.Writer = utils.WriterFunc(func(b []byte) (n int, err error) {
 					isHelp = true
-					buf.Write(b)
-					return len(b), nil
+					return buf.Write(b)
 				})
 
 				eventApp.CommandNotFound = func(c *cli.Context, command string) {

--- a/main.go
+++ b/main.go
@@ -130,8 +130,6 @@ func main() {
 		go rtm.ManageConnection()
 		channel := ""
 
-		log.Printf("[DEBUG] IncomingEvents: %#v\n", rtm.IncomingEvents)
-
 		for event := range rtm.IncomingEvents {
 			buf := bytes.NewBuffer(nil)
 			for _, b := range behavs {


### PR DESCRIPTION
When a user provides a command with either `-h` or `--help`, the bot should print the usage as a codeblock. Other commands for now should output as they already do.

Closes #1 